### PR TITLE
Repair CSS link line on gallery.html

### DIFF
--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -5,7 +5,7 @@
         <title>Gallery</title>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link rel="stylesheet" type="text/css" href="stylegallery.css"/>
+        <link rel="stylesheet" type="text/css" href="StyleGallery.css"/>
         
     </head>
     <body>


### PR DESCRIPTION
@JordanJ7 Your CSS link line was pointing to `stylegallery.css`, but in your repo, that CSS file has capital letters: `StyleGallery.css`. 

* Check on your computer (not here on the web repo): What is that CSS file named? See if it matches: `StyleGallery.css` or is it `stylegallery.css` on your machine? 

    * If it was really `StyleGallery.css` the whole time on your computer, then this fix should be what you need to get the CSS working locally and on your website. 
    *  However(!) If you find `stylegallery.css` on your computer, I wonder if you tried to rename that CSS file and **push the change to GitHub, and it didn't work?** (Note: This happens **a lot.**) Changing capitalization in filenames can be weirdly difficult: Your computer system might be *case insensitive*--meaning it might not recognize a change to capitalization.) You can use `git` to work around that and actually rename the file: read more about it on this Stack Overflow post: https://stackoverflow.com/questions/10523849/changing-capitalization-of-filenames-in-git 
    * If you were trying to rename that CSS file and couldn't push the change, then don't bother with this pull request, and instead follow the Stack Overflow, where you use a git command to make sure git tracking picks up the name change, so you can push it. 




