### PR TITLE
Fixing CSS Link LIne in on timeline.html

### DIFF
--- a/docs/timeline.html
+++ b/docs/timeline.html
@@ -5,7 +5,7 @@
         <title>Gallery</title>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link rel="stylesheet" type="text/css" href="stylegallery.css"/>
+        <link rel="stylesheet" type="text/css" href="StyleGallery.css"/>
         
     </head>
     <body>


### PR DESCRIPTION
Here again, the CSS link line is pointing to a `stylegallery.css` instead of `StyleGallery.css` which is what's actually in the web repo.